### PR TITLE
fix: change scale for qc plots

### DIFF
--- a/src/components/Plots/QCPlotMgr.js
+++ b/src/components/Plots/QCPlotMgr.js
@@ -10,10 +10,17 @@ const QCPlotMgr = (props) => {
             {
                 ["sums", "detected", "proportion"].map(x => {
                     const props2 = {
-                        "threshold": qcData?.["thresholds"]?.[x],
-                        "range": qcData?.["ranges"]?.[x],
+                        "threshold": x !== "proportion" ?
+                        Math.log2(qcData?.["thresholds"]?.[x]) : qcData?.["thresholds"]?.[x] * 100,
+                        "range": x !== "proportion" ? 
+                            qcData?.["ranges"]?.[x].map((x) => Math.log2(x + 1)) :
+                            qcData?.["ranges"]?.[x].map((x) => x * 100),
                         "label": x,
-                        "rdata": qcData?.["data"]?.[x]
+                        "showLabel": x !== "proportion" ? 
+                        x + " (log)" : x + " (%)",
+                        "rdata": x !== "proportion" ? 
+                            qcData?.["data"]?.[x].map((x) => Math.log2(x + 1)) :
+                            qcData?.["data"]?.[x].map((x) => x * 100)
                     }
                     return (
                         <div key={x}>

--- a/src/components/Plots/ViolinPlotBasic.js
+++ b/src/components/Plots/ViolinPlotBasic.js
@@ -44,7 +44,7 @@ const ViolinPlotBasic = (props) => {
 
         var x = d3.scaleBand()
             .range([0, width])
-            .domain([props?.label])
+            .domain([props?.showLabel])
             .padding(0.05)
 
         svg.append("g")


### PR DESCRIPTION
@LTLA 
I realize proportion is by feature/gene? -> https://github.com/jkanche/scran.js/blob/master/src/PerCellQCMetrics_Results.h#L47

so should there be a gene selection for the proportion plot? or completely remove proportion ?