### PR TITLE
Enable re-analysis of a Zipped ArtifactDB dataset.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "bakana": "2.0.15",
+    "bakana": "2.0.16",
     "bakana-remotes": "^1.0.2",
     "bioconductor": "^0.3.1",
     "d3": "^7.8.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "bakana": "2.0.14",
+    "bakana": "2.0.15",
     "bakana-remotes": "^1.0.2",
     "bioconductor": "^0.3.1",
     "d3": "^7.8.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kana",
   "description": "Single-cell data analysis in the browser",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "author": {
     "name": "Jayaram Kancherla",
     "email": "jayaram.kancherla@gmail.com",

--- a/src/components/ExploreMode/index.js
+++ b/src/components/ExploreMode/index.js
@@ -709,11 +709,18 @@ export function ExplorerMode() {
       if (resp?.annotations) {
         setAnnotationCols(resp.annotations);
 
-        let def_anno = Object.keys(resp.annotations)[0];
-        if (Object.keys(resp.annotations).indexOf("clusters") !== -1) {
-          def_anno = "clusters";
-        } else if (Object.keys(resp.annotations).indexOf("cluster") !== -1) {
-          def_anno = "cluster";
+        let def_anno = resp.annotations[0];
+        const categorical_annos = Object.keys(resp.annotations);
+        if (categorical_annos.length > 1) {
+          if (categorical_annos.indexOf(default_cluster) !== -1) {
+            def_anno = default_cluster;
+          } else if (categorical_annos.indexOf("kana::clusters") !== -1) {
+            def_anno = "kana::clusters";
+          } else if (categorical_annos.indexOf("cluster") !== -1) {
+            def_anno = "cluster";
+          } else if (categorical_annos.indexOf("clusters") !== -1) {
+            def_anno = "clusters";
+          }
         }
 
         setColorByAnnotation(def_anno);

--- a/src/components/LoadExplore/index.js
+++ b/src/components/LoadExplore/index.js
@@ -25,7 +25,9 @@ import { Tooltip2 } from "@blueprintjs/popover2";
 import { H5ADCard } from "./H5ADCard";
 import { SECard } from "./SECard";
 import { ZippedADBCard } from "./ZippedADBCard";
+
 import JSZip from "jszip";
+import { searchZippedArtifactdb } from "bakana";
 
 export function LoadExplore({ setShowPanel, ...props }) {
   // clear the entire panel
@@ -76,8 +78,9 @@ export function LoadExplore({ setShowPanel, ...props }) {
     setShowPanel("explore");
   };
 
-  // final inputs for confirmation with options
+  // final jszipnames for confirmation with options
   const [jsZipNames, setJsZipNames] = useState(null);
+  const [jsZipObjs, setJSZipObjs] = useState(null);
 
   // making sure tmpNewInputs are valid as the user chooses datasets
   useEffect(() => {
@@ -256,24 +259,19 @@ export function LoadExplore({ setShowPanel, ...props }) {
                     onInputChange={(msg) => {
                       if (msg.target.files) {
                         JSZip.loadAsync(msg.target.files[0]).then(
-                          function (zip) {
-                            let se_tld = [];
-                            zip.forEach(function (relativePath, zipEntry) {
-                              if (
-                                zipEntry.name.endsWith("/") &&
-                                zipEntry.name.split("/").length === 2
-                              ) {
-                                se_tld.push(zipEntry.name.split("/")[0]);
-                              }
-                            });
+                          async (zip) => {
+                            const objs = await searchZippedArtifactdb(zip);
+                            setJSZipObjs(objs);
+
+                            const objNames = Array.from(objs.keys());
+                            setJsZipNames(objNames);
 
                             setTmpStatusValid(true);
-                            setJsZipNames(se_tld);
 
                             setTmpLoadInputs({
                               ...tmpLoadInputs,
                               zipfile: msg.target.files[0],
-                              zipname: se_tld[0],
+                              zipname: objNames[0],
                             });
                           },
                           function (e) {
@@ -294,7 +292,7 @@ export function LoadExplore({ setShowPanel, ...props }) {
                 {jsZipNames && jsZipNames.length > 0 && (
                   <Label className="row-input">
                     <Text className="text-100">
-                      <span>Choose a summarized experiment to load</span>
+                      <span>Choose an experiment to load</span>
                     </Text>
                     <HTMLSelect
                       defaultValue={jsZipNames[0]}
@@ -308,7 +306,7 @@ export function LoadExplore({ setShowPanel, ...props }) {
                       {jsZipNames.map((x, i) => {
                         return (
                           <option key={i} value={x}>
-                            {x}
+                            {x} ({jsZipObjs.get(x)[0]}, {jsZipObjs.get(x)[1]})
                           </option>
                         );
                       })}

--- a/src/components/LoadExplore/index.js
+++ b/src/components/LoadExplore/index.js
@@ -306,7 +306,7 @@ export function LoadExplore({ setShowPanel, ...props }) {
                       {jsZipNames.map((x, i) => {
                         return (
                           <option key={i} value={x}>
-                            {x} ({jsZipObjs.get(x)[0]}, {jsZipObjs.get(x)[1]})
+                            {x} ({jsZipObjs.get(x)[0]} x {jsZipObjs.get(x)[1]})
                           </option>
                         );
                       })}

--- a/src/components/NewAnalysis/ZippedADBCard.js
+++ b/src/components/NewAnalysis/ZippedADBCard.js
@@ -211,7 +211,7 @@ export function ZippedADB({
       </div>
       <div className={dsMeta ? "" : "bp4-skeleton"}>
         <p>
-          This <strong>RDS</strong> dataset contains{" "}
+          This <strong>ZIP</strong> dataset contains{" "}
           {dsMeta && dsMeta.cells.numberOfCells} cells and the following feature
           types: {dsMeta && reportFeatureTypes(dsMeta.modality_features)}
         </p>

--- a/src/components/NewAnalysis/ZippedADBCard.js
+++ b/src/components/NewAnalysis/ZippedADBCard.js
@@ -1,0 +1,375 @@
+import { useState, useEffect } from "react";
+
+import {
+  Label,
+  Text,
+  HTMLSelect,
+  ButtonGroup,
+  Button,
+  Divider,
+  Callout,
+  Collapse,
+  FormGroup,
+  EditableText,
+} from "@blueprintjs/core";
+
+import "./index.css";
+
+import { MODALITIES } from "../../utils/utils";
+
+import { reportFeatureTypes } from "./utils";
+
+export function ZippedADB({
+  resource,
+  index,
+  preflight,
+  inputOpts,
+  setInputOpts,
+  inputs,
+  setInputs,
+  ...props
+}) {
+  const [dsMeta, setDsMeta] = useState(null);
+  const [options, setOptions] = useState({});
+  const [collapse, setCollapse] = useState(true);
+  const [init2, setInit2] = useState(true);
+
+  // when preflight is available
+  useEffect(() => {
+    if (preflight && preflight !== null && preflight !== undefined) {
+      setDsMeta(preflight);
+
+      // set some defaults
+      if (init2) {
+        let tmpOptions = guessModalities(preflight);
+        setOptions(tmpOptions);
+        setInit2(false);
+      }
+    }
+  }, [preflight]);
+
+  // when options change
+  useEffect(() => {
+    if (options !== {}) {
+      let tmpInputOpts = [...inputOpts];
+      tmpInputOpts[index] = options;
+      setInputOpts(tmpInputOpts);
+    }
+  }, [options]);
+
+  useEffect(() => {
+    let tmpOptions = { ...options };
+    if (
+      options !== {} &&
+      "adtExperiment" in options &&
+      options["adtExperiment"] !== "none" &&
+      options["adtExperiment"] !== null &&
+      options["adtExperiment"] !== undefined
+    ) {
+      tmpOptions["adtCountAssay"] =
+        preflight.modality_assay_names[options?.["adtExperiment"]][0];
+      tmpOptions["primaryAdtFeatureIdColumn"] = Object.keys(
+        preflight.modality_features[options?.["adtExperiment"]].columns
+      )[0];
+    } else {
+      delete tmpOptions["adtCountAssay"];
+      delete tmpOptions["primaryAdtFeatureIdColumn"];
+    }
+    setOptions(tmpOptions);
+  }, [options?.["adtExperiment"]]);
+
+  useEffect(() => {
+    let tmpOptions = { ...options };
+    if (
+      options !== {} &&
+      "crisprExperiment" in options &&
+      options["crisprExperiment"] !== "none" &&
+      options["crisprExperiment"] !== null &&
+      options["crisprExperiment"] !== undefined
+    ) {
+      tmpOptions["crisprCountAssay"] =
+        preflight.modality_assay_names[options?.["crisprExperiment"]][0];
+      tmpOptions["primaryCrisprFeatureIdColumn"] = Object.keys(
+        preflight.modality_features[options?.["crisprExperiment"]].columns
+      )[0];
+    } else {
+      delete tmpOptions["crisprCountAssay"];
+      delete tmpOptions["primaryCrisprFeatureIdColumn"];
+    }
+    setOptions(tmpOptions);
+  }, [options?.["crisprExperiment"]]);
+
+  useEffect(() => {
+    let tmpOptions = { ...options };
+    if (
+      options !== {} &&
+      "rnaExperiment" in options &&
+      options["rnaExperiment"] !== "none" &&
+      options["rnaExperiment"] !== null &&
+      options["rnaExperiment"] !== undefined
+    ) {
+      tmpOptions["rnaCountAssay"] =
+        preflight.modality_assay_names[options?.["rnaExperiment"]][0];
+      tmpOptions["primaryRnaFeatureIdColumn"] = Object.keys(
+        preflight.modality_features[options?.["rnaExperiment"]].columns
+      )[0];
+    } else {
+      delete tmpOptions["rnaCountAssay"];
+      delete tmpOptions["primaryRnaFeatureIdColumn"];
+    }
+    setOptions(tmpOptions);
+  }, [options?.["rnaExperiment"]]);
+
+  useEffect(() => {
+    setCollapse(props?.expand);
+  }, [props?.expand]);
+
+  const getAvailableModalities = (modality) => {
+    return Object.keys(dsMeta.modality_features);
+  };
+
+  const getCamelCaseKey = (mod) => {
+    return (
+      mod.toLowerCase().charAt(0).toUpperCase() + mod.toLowerCase().slice(1)
+    );
+  };
+
+  const getFTypeKey = (mod) => {
+    return `${mod.toLowerCase()}Experiment`;
+  };
+
+  const resetModality = (mod, val) => {
+    let tmpOptions = { ...options };
+
+    const remaining_modalities = MODALITIES.filter((x) => x !== mod);
+
+    for (const rm of remaining_modalities) {
+      if (val === tmpOptions?.[getFTypeKey(rm)]) {
+        tmpOptions[getFTypeKey(rm)] = null;
+      }
+    }
+
+    return tmpOptions;
+  };
+
+  function guessModalities(preflight) {
+    let tmpOptions = {
+      rnaExperiment: null,
+      adtExperiment: null,
+      crisprExperiment: null,
+    };
+    for (const [k, v] of Object.entries(preflight.modality_features)) {
+      if (k === "" || k.toLowerCase().indexOf("gene") > -1) {
+        tmpOptions["rnaExperiment"] = k;
+        tmpOptions["rnaCountAssay"] = preflight.modality_assay_names[k][0];
+        tmpOptions["primaryRnaFeatureIdColumn"] = Object.keys(v.columns)[0];
+      } else if (
+        k.toLowerCase().indexOf("antibody") > -1 ||
+        k.toLowerCase().indexOf("adt") > -1
+      ) {
+        tmpOptions["adtExperiment"] = k;
+        tmpOptions["adtCountAssay"] = preflight.modality_assay_names[k][0];
+        tmpOptions["primaryAdtFeatureIdColumn"] = Object.keys(v.columns)[0];
+      } else if (k.toLowerCase().indexOf("crispr") > -1) {
+        tmpOptions["crisprExperiment"] = k;
+        tmpOptions["crisprCountAssay"] = preflight.modality_assay_names[k][0];
+        tmpOptions["primaryCrisprFeatureIdColumn"] = Object.keys(v.columns)[0];
+      }
+    }
+    return tmpOptions;
+  }
+
+  const handleRemove = () => {
+    let tmpInputs = [...inputs];
+    tmpInputs.splice(index, 1);
+    setInputs(tmpInputs);
+
+    let tmpInputOpts = [...inputOpts];
+    tmpInputOpts.splice(index, 1);
+    setInputOpts(tmpInputOpts);
+  };
+
+  return (
+    <Callout className="section-input-item">
+      <div className="section-input-item-header">
+        <EditableText
+          intent="primary"
+          confirmOnEnterKey={true}
+          defaultValue={resource.name}
+          alwaysRenderInput={true}
+        />
+        <ButtonGroup minimal={true}>
+          <Button
+            icon={collapse ? "minimize" : "maximize"}
+            minimal={true}
+            onClick={() => {
+              setCollapse(!collapse);
+            }}
+          />
+          <Button icon="cross" minimal={true} onClick={handleRemove} />
+        </ButtonGroup>
+      </div>
+      <div className={dsMeta ? "" : "bp4-skeleton"}>
+        <p>
+          This <strong>RDS</strong> dataset contains{" "}
+          {dsMeta && dsMeta.cells.numberOfCells} cells and the following feature
+          types: {dsMeta && reportFeatureTypes(dsMeta.modality_features)}
+        </p>
+        <Collapse isOpen={collapse}>
+          <div>
+            {dsMeta &&
+              MODALITIES.map((mod, i) => {
+                return (
+                  <div key={options[getFTypeKey(mod)] + i}>
+                    <Divider />
+                    <Label className="row-input">
+                      <Text>
+                        <strong>{mod} modality</strong>
+                      </Text>
+                      <HTMLSelect
+                        defaultValue={
+                          options[getFTypeKey(mod)] !== null &&
+                          options[getFTypeKey(mod)] !== undefined
+                            ? options[getFTypeKey(mod)]
+                            : "none"
+                        }
+                        onChange={(e) => {
+                          if (
+                            e.target.value !== undefined &&
+                            e.target.value !== null
+                          ) {
+                            let tmpOptions = resetModality(
+                              mod,
+                              e.target.value === "none" ? null : e.target.value
+                            );
+                            if (e.target.value === "none") {
+                              tmpOptions[getFTypeKey(mod)] = null;
+                            } else {
+                              tmpOptions[getFTypeKey(mod)] = e.target.value;
+                            }
+                            setOptions(tmpOptions);
+                          }
+                        }}
+                      >
+                        <option value="none">--- no selection ---</option>
+                        {getAvailableModalities(mod).map((x, i) => (
+                          <option key={i} value={x}>
+                            {x === "" ? "unnamed" : x}
+                          </option>
+                        ))}
+                      </HTMLSelect>
+                    </Label>
+                    <FormGroup
+                      disabled={
+                        options?.[getFTypeKey(mod)] === undefined ||
+                        options?.[getFTypeKey(mod)] === null ||
+                        options?.[getFTypeKey(mod)] === "none"
+                      }
+                    >
+                      <Label className="row-input">
+                        <Text>
+                          <strong>{mod} count assay</strong>
+                        </Text>
+                        <HTMLSelect
+                          defaultValue={
+                            options?.[getFTypeKey(mod)]
+                              ? dsMeta.modality_assay_names[
+                                  options?.[getFTypeKey(mod)]
+                                ][0]
+                              : null
+                          }
+                          onChange={(e) => {
+                            if (
+                              e.target.value !== undefined &&
+                              e.target.value !== null
+                            ) {
+                              let tmpOptions = { ...options };
+                              if (e.target.value === "none") {
+                                tmpOptions[`${mod.toLowerCase()}CountAssay`] =
+                                  null;
+                              } else {
+                                tmpOptions[`${mod.toLowerCase()}CountAssay`] =
+                                  e.target.value;
+                              }
+                              setOptions(tmpOptions);
+                            }
+                          }}
+                        >
+                          {dsMeta.modality_assay_names[
+                            options?.[getFTypeKey(mod)]
+                          ] &&
+                            dsMeta.modality_assay_names[
+                              options[getFTypeKey(mod)]
+                            ].map((x, i) => (
+                              <option key={i} value={x}>
+                                {x}
+                              </option>
+                            ))}
+                        </HTMLSelect>
+                      </Label>
+                    </FormGroup>
+                    <FormGroup
+                      disabled={
+                        options?.[getFTypeKey(mod)] === undefined ||
+                        options?.[getFTypeKey(mod)] === null ||
+                        options?.[getFTypeKey(mod)] === "none"
+                      }
+                    >
+                      <Label className="row-input">
+                        <Text>
+                          <strong>{mod} primary feature ID</strong>
+                        </Text>
+                        <HTMLSelect
+                          disabled={
+                            options?.[getFTypeKey(mod)] === undefined ||
+                            options?.[getFTypeKey(mod)] === null ||
+                            options?.[getFTypeKey(mod)] === "none"
+                          }
+                          defaultValue="none"
+                          onChange={(e) => {
+                            if (e.target.value) {
+                              let tmpOptions = { ...options };
+                              if (e.target.value === "none") {
+                                tmpOptions[
+                                  `primary${
+                                    mod.toLowerCase().charAt(0).toUpperCase() +
+                                    mod.toLowerCase().slice(1)
+                                  }FeatureIdColumn`
+                                ] = null;
+                              } else {
+                                tmpOptions[
+                                  `primary${
+                                    mod.toLowerCase().charAt(0).toUpperCase() +
+                                    mod.toLowerCase().slice(1)
+                                  }FeatureIdColumn`
+                                ] = e.target.value;
+                              }
+                              setOptions(tmpOptions);
+                            }
+                          }}
+                        >
+                          <option value="none">rownames</option>
+                          {dsMeta.modality_features[
+                            options?.[getFTypeKey(mod)]
+                          ]?.["columns"] &&
+                            Object.keys(
+                              dsMeta.modality_features[
+                                options[getFTypeKey(mod)]
+                              ]["columns"]
+                            ).map((x, i) => (
+                              <option key={i} value={x}>
+                                {x}
+                              </option>
+                            ))}
+                        </HTMLSelect>
+                      </Label>
+                    </FormGroup>
+                  </div>
+                );
+              })}
+          </div>
+        </Collapse>
+      </div>
+    </Callout>
+  );
+}

--- a/src/components/NewAnalysis/index.js
+++ b/src/components/NewAnalysis/index.js
@@ -35,6 +35,7 @@ import { TenxHDF5 } from "./TenxHDF5Card";
 import { code } from "../../utils/utils";
 import { H5AD } from "./H5ADCard";
 import { RDSSE } from "./RDSSECard";
+import { ZippedADB } from "./ZippedADBCard";
 
 export function NewAnalysis({ setShowPanel, setStateIndeterminate, ...props }) {
   // close the entire panel
@@ -253,6 +254,12 @@ export function NewAnalysis({ setShowPanel, setStateIndeterminate, ...props }) {
         }
 
         if (!x.rds) all_valid = false;
+      } else if (x.format === "ZippedADB") {
+        if (x?.zip && !x?.zip.name.toLowerCase().endsWith("zip")) {
+          all_valid = false;
+        }
+
+        if (!x.zip) all_valid = false;
       } else if (x.format === "ExperimentHub") {
         if (x?.id && !(ehubDatasets.indexOf(x?.id) !== -1)) {
           all_valid = false;
@@ -590,6 +597,45 @@ export function NewAnalysis({ setShowPanel, setStateIndeterminate, ...props }) {
                         setTmpNewInputs({
                           ...tmpNewInputs,
                           rds: msg.target.files[0],
+                        });
+                      }
+                    }}
+                  />
+                </Label>
+              </div>
+            </>
+          }
+        />
+        <Tab
+          id="ZippedADB"
+          title="ZIP"
+          panel={
+            <>
+              <div className="row">
+                <Callout intent="primary">
+                  <p>
+                    Load a ZIP (<Code>*.zip</Code>) file containing an ArtifactDB-formatted
+                    <Code>SummarizedExperiment</Code> object. For example, users may 
+                    provide the ZIP file created from a previous <strong>kana</strong>{" "} 
+                    session via the <em>Save analysis results</em> option.
+                  </p>
+                </Callout>
+              </div>
+              <div className="row">
+                <Label className="row-input">
+                  <Text className="text-100">
+                    <span>Choose a ZIP File</span>
+                  </Text>
+                  <FileInput
+                    style={{
+                      marginTop: "5px",
+                    }}
+                    text={tmpNewInputs?.zip ? tmpNewInputs?.zip.name : ".zip"}
+                    onInputChange={(msg) => {
+                      if (msg.target.files) {
+                        setTmpNewInputs({
+                          ...tmpNewInputs,
+                          zip: msg.target.files[0],
                         });
                       }
                     }}
@@ -989,6 +1035,22 @@ export function NewAnalysis({ setShowPanel, setStateIndeterminate, ...props }) {
               } else if (x.format === "SummarizedExperiment") {
                 return (
                   <RDSSE
+                    key={i}
+                    expand={i + 1 === tmpFiles.length}
+                    resource={x}
+                    index={i}
+                    preflight={
+                      preInputFilesStatus && preInputFilesStatus[x.name]
+                    }
+                    inputOpts={inputOptions}
+                    setInputOpts={setInputOptions}
+                    inputs={tmpFiles}
+                    setInputs={setTmpFiles}
+                  />
+                );
+              } else if (x.format === "ZippedADB") {
+                return (
+                  <ZippedADB
                     key={i}
                     expand={i + 1 === tmpFiles.length}
                     resource={x}

--- a/src/components/NewAnalysis/index.js
+++ b/src/components/NewAnalysis/index.js
@@ -690,7 +690,7 @@ export function NewAnalysis({ setShowPanel, setStateIndeterminate, ...props }) {
                       {jsZipNames.map((x, i) => {
                         return (
                           <option key={i} value={x}>
-                            {x} ({jsZipObjs.get(x)[0]}, {jsZipObjs.get(x)[1]})
+                            {x} ({jsZipObjs.get(x)[0]} x {jsZipObjs.get(x)[1]})
                           </option>
                         );
                       })}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -127,6 +127,9 @@ export function generateUID(resource) {
     case "ZippedArtifactdb":
       base += `::${resource.zipname}::${resource.zipfile}`;
       return utf8_to_b64(base);
+    case "ZippedADB":
+      base += `::${resource.zipname}::${resource.zipfile}`;
+      return utf8_to_b64(base);
     default:
       throw Error(`format: ${resource.format} does not exist`);
       break;

--- a/src/workers/explorer.worker.js
+++ b/src/workers/explorer.worker.js
@@ -41,9 +41,10 @@ function createDataset(args, setOpts = false) {
 }
 
 function summarizeResult(summary, args) {
+  // TODO: figure out a way to deal with nested objects later
   let cells_summary = {};
   for (const k of summary.cells.columnNames()) {
-    let kcol = summary.cells.column(k);
+    const kcol = summary.cells.column(k);
     if (Array.isArray(kcol) || ArrayBuffer.isView(kcol))
       cells_summary[k] = bakana.summarizeArray(kcol);
   }
@@ -63,12 +64,11 @@ function summarizeResult(summary, args) {
       for (const [k, v] of Object.entries(summary.modality_features)) {
         let tmod_summary = {};
         for (const k of v.columnNames()) {
-          // TODO: figure out a way to deal with these later
-          if (!Array.isArray(v.column(k))) {
-            continue;
+          const kcol = v.column(k);
+          if (Array.isArray(kcol) || ArrayBuffer.isView(kcol)) {
+            tmod_summary[k] = bakana.summarizeArray(kcol);
+            tmod_summary[k]["_all_"] = kcol;
           }
-          tmod_summary[k] = bakana.summarizeArray(v.column(k));
-          tmod_summary[k]["_all_"] = v.column(k);
         }
         tmp_meta["modality_features"][k] = {
           columns: tmod_summary,
@@ -81,10 +81,11 @@ function summarizeResult(summary, args) {
     tmp_meta["all_features"] = {};
     let tmod_summary = {};
     for (const k of summary["all_features"].columnNames()) {
-      tmod_summary[k] = bakana.summarizeArray(
-        summary["all_features"].column(k)
-      );
-      tmod_summary[k]["_all_"] = summary["all_features"].column(k);
+      const kcol = summary["all_features"].column(k);
+      if (Array.isArray(kcol) || ArrayBuffer.isView(kcol)) {
+        tmod_summary[k] = bakana.summarizeArray(kcol);
+        tmod_summary[k]["_all_"] = kcol;
+      }
     }
     tmp_meta["all_features"] = {
       columns: tmod_summary,

--- a/src/workers/scran.worker.js
+++ b/src/workers/scran.worker.js
@@ -559,11 +559,23 @@ onmessage = function (msg) {
       .then(async (x) => {
         let files = await bakana.saveSingleCellExperiment(
           superstate,
-          "results",
+          "sce",
           {
             forceBuffer: true,
           }
         );
+
+        let gene_files = await bakana.saveGenewiseResults(
+          superstate,
+          "",
+          {
+            forceBuffer: true,
+          }
+        );
+
+        for (const f of gene_files) {
+          files.push(f);
+        }
         let zipbuffer = await bakana.zipFiles(files);
 
         postMessage(

--- a/src/workers/scran.worker.js
+++ b/src/workers/scran.worker.js
@@ -49,8 +49,8 @@ function createDataset(args) {
     );
   } else if (args.format === "ZippedADB") {
     return new bakana.ZippedArtifactdbDataset(
-      "results", // TODO: add choice of name.
-      args.zip,
+      args.zipname,
+      args.zipfile,
       args.options ? args.options : {}
     );
   } else if (args.format === "ExperimentHub") {
@@ -126,7 +126,10 @@ function summarizeDataset(summary, args) {
 
   if (args.format === "H5AD") {
     tmp_meta["all_assay_names"] = summary.all_assay_names;
-  } else if (args.format === "SummarizedExperiment") {
+  } else if (
+    args.format === "SummarizedExperiment" ||
+    args.format === "ZippedADB"
+  ) {
     tmp_meta["modality_assay_names"] = summary.modality_assay_names;
   }
   return tmp_meta;
@@ -557,21 +560,13 @@ onmessage = function (msg) {
   } else if (type === "EXPORT_RDS") {
     loaded
       .then(async (x) => {
-        let files = await bakana.saveSingleCellExperiment(
-          superstate,
-          "sce",
-          {
-            forceBuffer: true,
-          }
-        );
+        let files = await bakana.saveSingleCellExperiment(superstate, "sce", {
+          forceBuffer: true,
+        });
 
-        let gene_files = await bakana.saveGenewiseResults(
-          superstate,
-          "",
-          {
-            forceBuffer: true,
-          }
-        );
+        let gene_files = await bakana.saveGenewiseResults(superstate, "", {
+          forceBuffer: true,
+        });
 
         for (const f of gene_files) {
           files.push(f);

--- a/src/workers/scran.worker.js
+++ b/src/workers/scran.worker.js
@@ -68,7 +68,7 @@ function summarizeDataset(summary, args) {
   let cells_summary = {};
   for (const k of summary.cells.columnNames()) {
     const kcol = summary.cells.column(k);
-    if (Array.isArray(kcol)) {
+    if (Array.isArray(kcol) || ArrayBuffer.isView(kcol)) {
       cells_summary[k] = bakana.summarizeArray(kcol);
     }
   }
@@ -84,7 +84,7 @@ function summarizeDataset(summary, args) {
     let tmod_summary = {};
     for (const k of summary["all_features"].columnNames()) {
       const kcol = summary["all_features"].column(k);
-      if (Array.isArray(kcol)) {
+      if (Array.isArray(kcol) || ArrayBuffer.isView(kcol)) {
         tmod_summary[k] = bakana.summarizeArray(kcol);
         tmod_summary[k]["_all_"] = kcol;
       }
@@ -101,7 +101,7 @@ function summarizeDataset(summary, args) {
         let tmod_summary = {};
         for (const k of v.columnNames()) {
           const kcol = v.column(k);
-          if (Array.isArray(kcol)) {
+          if (Array.isArray(kcol) || ArrayBuffer.isView(kcol)) {
             tmod_summary[k] = bakana.summarizeArray(kcol);
             tmod_summary[k]["_all_"] = kcol;
           }
@@ -120,7 +120,7 @@ function summarizeDataset(summary, args) {
         let tmod_summary = {};
         for (const k of v.columnNames()) {
           const kcol = v.column(k);
-          if (Array.isArray(kcol)) {
+          if (Array.isArray(kcol) || ArrayBuffer.isView(kcol)) {
             tmod_summary[k] = bakana.summarizeArray(kcol);
             tmod_summary[k]["_all_"] = kcol;
           }

--- a/src/workers/scran.worker.js
+++ b/src/workers/scran.worker.js
@@ -47,6 +47,12 @@ function createDataset(args) {
       args.rds,
       args.options ? args.options : {}
     );
+  } else if (args.format === "ZippedADB") {
+    return new bakana.ZippedArtifactdbDataset(
+      "results", // TODO: add choice of name.
+      args.zip,
+      args.options ? args.options : {}
+    );
   } else if (args.format === "ExperimentHub") {
     return new remotes.ExperimentHubDataset(
       args.id,

--- a/src/workers/scran.worker.js
+++ b/src/workers/scran.worker.js
@@ -64,9 +64,13 @@ function createDataset(args) {
 }
 
 function summarizeDataset(summary, args) {
+  // TODO: figure out a way to deal with nested dataframes later
   let cells_summary = {};
   for (const k of summary.cells.columnNames()) {
-    cells_summary[k] = bakana.summarizeArray(summary.cells.column(k));
+    const kcol = summary.cells.column(k);
+    if (Array.isArray(kcol)) {
+      cells_summary[k] = bakana.summarizeArray(kcol);
+    }
   }
   let tmp_meta = {
     cells: {
@@ -79,10 +83,11 @@ function summarizeDataset(summary, args) {
     tmp_meta["all_features"] = {};
     let tmod_summary = {};
     for (const k of summary["all_features"].columnNames()) {
-      tmod_summary[k] = bakana.summarizeArray(
-        summary["all_features"].column(k)
-      );
-      tmod_summary[k]["_all_"] = summary["all_features"].column(k);
+      const kcol = summary["all_features"].column(k);
+      if (Array.isArray(kcol)) {
+        tmod_summary[k] = bakana.summarizeArray(kcol);
+        tmod_summary[k]["_all_"] = kcol;
+      }
     }
     tmp_meta["all_features"] = {
       columns: tmod_summary,
@@ -94,12 +99,11 @@ function summarizeDataset(summary, args) {
       for (const [k, v] of Object.entries(summary.modality_features)) {
         let tmod_summary = {};
         for (const k of v.columnNames()) {
-          // TODO: figure out a way to deal with these later
-          if (!Array.isArray(v.column(k))) {
-            continue;
+          const kcol = v.column(k);
+          if (Array.isArray(kcol)) {
+            tmod_summary[k] = bakana.summarizeArray(kcol);
+            tmod_summary[k]["_all_"] = kcol;
           }
-          tmod_summary[k] = bakana.summarizeArray(v.column(k));
-          tmod_summary[k]["_all_"] = v.column(k);
         }
         tmp_meta["modality_features"][k] = {
           columns: tmod_summary,
@@ -113,8 +117,11 @@ function summarizeDataset(summary, args) {
       for (const [k, v] of Object.entries(summary.modality_features)) {
         let tmod_summary = {};
         for (const k of v.columnNames()) {
-          tmod_summary[k] = bakana.summarizeArray(v.column(k));
-          tmod_summary[k]["_all_"] = v.column(k);
+          const kcol = v.column(k);
+          if (Array.isArray(kcol)) {
+            tmod_summary[k] = bakana.summarizeArray(kcol);
+            tmod_summary[k]["_all_"] = kcol;
+          }
         }
         tmp_meta["modality_features"][k] = {
           columns: tmod_summary,


### PR DESCRIPTION
- [x] Need to add code to choose an appropriate `name`, use the new `bakana.searchZippedArtifactdb`.
- [x] Need to filter out nested DFs from the summaries.

Closes #185 