### PR TITLE
Fixed marker reporting for the custom selections.

### DIFF
--- a/src/workers/explorer.worker.js
+++ b/src/workers/explorer.worker.js
@@ -684,7 +684,7 @@ onmessage = function (msg) {
           ];
           marker_resp = bakana.formatMarkerResults(
             raw_res,
-            payload.cluster,
+            1,
             payload.rank_type
           );
         } else {

--- a/src/workers/explorer.worker.js
+++ b/src/workers/explorer.worker.js
@@ -488,7 +488,7 @@ onmessage = function (msg) {
         ];
         let resp = bakana.formatMarkerResults(
           raw_res,
-          payload.cluster,
+          1,
           rank_type
         );
 

--- a/src/workers/scran.worker.js
+++ b/src/workers/scran.worker.js
@@ -1156,7 +1156,7 @@ onmessage = function (msg) {
           ];
           marker_resp = bakana.formatMarkerResults(
             raw_res,
-            payload.cluster,
+            1,
             payload.rank_type
           );
         } else {

--- a/src/workers/scran.worker.js
+++ b/src/workers/scran.worker.js
@@ -922,7 +922,7 @@ onmessage = function (msg) {
         )[payload.modality];
         let resp = bakana.formatMarkerResults(
           raw_res,
-          payload.cluster,
+          1,
           payload.rank_type
         );
 


### PR DESCRIPTION
`CustomSelectionsState#fetchResults(<selection_name>)` will return a `ScoreMarkersResults` object, but inside that object, the selection is encoded as group 1 (as mentioned [here](https://www.kanaverse.org/bakana/CustomSelectionsState.html#fetchResults)); you can't pass a name string in there, as Embind will probably just guess and convert it to zero. 

Same for the standalone, but I haven't checked out where that is.

Imagine that this is kind of like how we have to decrement in `MarkerDetectionState#fetchResults`. 

Closes #184, probably.