### PR TITLE
Wait for transactions to actually complete in IndexedDB write operations.

### DIFF
--- a/src/workers/DownloadsDBHandler.js
+++ b/src/workers/DownloadsDBHandler.js
@@ -1,10 +1,10 @@
 var DownloadsDB;
 var init = null;
 
-function complete(trans) {
+function complete_write(trans) {
   // The Promise's function should evaluate immediately
   // (see https://stackoverflow.com/questions/35177230/are-promises-lazily-evaluated) 
-  // and the callbacks should be attached to the transaction before we return to the event loop.
+  // so the callbacks should be attached to the transaction before we return to the event loop.
   return new Promise((resolve, reject) => {
     trans.oncomplete = (event) => {
       resolve(null);
@@ -46,26 +46,13 @@ export function initialize() {
   return init;
 }
 
-export async function list() {
-  await init;
-  let trans = DownloadsDB.result.transaction(["downloads"], "readonly");
-  let fin = complete(trans);
-
-  let download_store = trans.objectStore("downloads");
-  let listing = download_store.getAllKeys();
-
-  await fin;
-  return listing;
-}
-
 export async function get(url, params = null, force = false) {
   await init;
 
   if (!force) {
     let trans = DownloadsDB.result.transaction(["downloads"], "readonly");
-    let fin = complete(trans);
-
     let download_store = trans.objectStore("downloads");
+
     var data_check = new Promise((resolve) => {
       var already = download_store.get(url);
       already.onsuccess = function (event) {
@@ -81,7 +68,6 @@ export async function get(url, params = null, force = false) {
     });
 
     var found = await data_check;
-    await fin;
     if (found !== null) {
       return found;
     }
@@ -108,7 +94,7 @@ export async function get(url, params = null, force = false) {
   // we can't do an async fetch while the transaction is still open, because
   // it just closes before the fetch is done.)
   let trans = DownloadsDB.result.transaction(["downloads"], "readwrite");
-  let fin = complete(trans);
+  let fin = complete_write(trans);
 
   let download_store = trans.objectStore("downloads");
   var data_saving = new Promise((resolve) => {
@@ -133,7 +119,7 @@ export async function get(url, params = null, force = false) {
 export async function remove(url) {
   await init;
   let trans = DownloadsDB.result.transaction(["downloads"], "readwrite");
-  let fin = complete(trans);
+  let fin = complete_write(trans);
 
   let download_store = trans.objectStore("downloads");
   var removal = new Promise((resolve) => {

--- a/src/workers/KanaDBHandler.js
+++ b/src/workers/KanaDBHandler.js
@@ -126,7 +126,7 @@ export async function saveFile(id, buffer) {
     };
 
     request.onerror = event => {
-      reject(new Error(`failed to save file ${id} in KanaDB: ${event.target.errorCode}`));
+      reject(new Error(`failed to retrieve metadata ${id} in KanaDB: ${event.target.errorCode}`));
     };
   }));
 
@@ -170,12 +170,13 @@ export async function saveAnalysis(id, state, files, title) {
       };
     });
 
-    return Promise.all([data_saving, id_saving]);
+    return Promise.all([data_saving, id_saving]).then(x => new_id);
   };
 
+  let output;
   if (id === null) {
     let request = meta_store.getAll();
-    await (new Promise((resolve, reject) => {
+    output = await (new Promise((resolve, reject) => {
       request.onsuccess = event => {
         resolve(callback(String(request.result.length)));
       };
@@ -184,11 +185,11 @@ export async function saveAnalysis(id, state, files, title) {
       };
     }));
   } else {
-    await callback(id);
+    output = await callback(id);
   }
 
   await fin;
-  return;
+  return output;
 }
 
 /** Functions to load content **/

--- a/src/workers/KanaDBHandler.js
+++ b/src/workers/KanaDBHandler.js
@@ -1,7 +1,7 @@
 var kanaDB;
 var init = null;
 
-function complete(trans) {
+function complete_write(trans) {
   // See comments in DownloadsDB about the validity of wrapping this in a Promise.
   return new Promise((resolve, reject) => {
     trans.oncomplete = (event) => {
@@ -115,7 +115,7 @@ export async function getRecords() {
 export async function saveFile(id, buffer) {
   await init;
   let trans = kanaDB.result.transaction(["file", "file_meta"], "readwrite");
-  let fin = complete(trans);
+  let fin = complete_write(trans);
   let file_store = trans.objectStore("file");
   let meta_store = trans.objectStore("file_meta");
 
@@ -160,7 +160,7 @@ export async function saveAnalysis(id, state, files, title) {
     ["analysis", "analysis_meta"],
     "readwrite"
   );
-  let fin = complete(trans);
+  let fin = complete_write(trans);
   let analysis_store = trans.objectStore("analysis");
   let meta_store = trans.objectStore("analysis_meta");
 
@@ -225,7 +225,7 @@ export async function loadAnalysis(id) {
 export async function removeFile(id) {
   await init;
   let trans = kanaDB.result.transaction(["file", "file_meta"], "readwrite");
-  let fin = complete(trans);
+  let fin = complete_write(trans);
   let file_store = trans.objectStore("file");
   let meta_store = trans.objectStore("file_meta");
 
@@ -285,7 +285,7 @@ export async function removeAnalysis(id) {
     ["analysis", "analysis_meta"],
     "readwrite"
   );
-  let fin = complete(trans);
+  let fin = complete_write(trans);
   let analysis_store = trans.objectStore("analysis");
   let meta_store = trans.objectStore("analysis_meta");
 

--- a/src/workers/scran.worker.js
+++ b/src/workers/scran.worker.js
@@ -628,19 +628,12 @@ onmessage = function (msg) {
         let config = enc.encode(JSON.stringify(collected));
         let id = await kana_db.saveAnalysis(null, config, collected, title);
 
-        if (id !== null) {
-          let recs = await kana_db.getRecords();
-          postMessage({
-            type: "KanaDB_store",
-            resp: recs,
-            msg: `Success: Saved analysis to browser (${id})`,
-          });
-        } else {
-          postMessage({
-            type: "KanaDB_ERROR",
-            msg: `Fail: Cannot save analysis to browser`,
-          });
-        }
+        let recs = await kana_db.getRecords();
+        postMessage({
+          type: "KanaDB_store",
+          resp: recs,
+          msg: `Success: Saved analysis to browser (${id})`,
+        });
       })
       .catch((err) => {
         console.error(err);
@@ -654,19 +647,12 @@ onmessage = function (msg) {
     kana_db
       .removeAnalysis(id)
       .then(async (output) => {
-        if (output) {
-          let recs = await kana_db.getRecords();
-          postMessage({
-            type: "KanaDB_store",
-            resp: recs,
-            msg: `Success: Removed file from cache (${id})`,
-          });
-        } else {
-          postMessage({
-            type: "KanaDB_ERROR",
-            msg: `fail: cannot remove file from cache (${id})`,
-          });
-        }
+        let recs = await kana_db.getRecords();
+        postMessage({
+          type: "KanaDB_store",
+          resp: recs,
+          msg: `Success: Removed file from cache (${id})`,
+        });
       })
       .catch((err) => {
         console.error(err);

--- a/src/workers/scran.worker.js
+++ b/src/workers/scran.worker.js
@@ -176,10 +176,7 @@ function linkKanaDb(collected) {
     let buffer = file.buffer();
     var md5 = await hashwasm.md5(buffer);
     var id = type + "_" + file.name() + "_" + buffer.length + "_" + md5;
-    var ok = await kana_db.saveFile(id, buffer);
-    if (!ok) {
-      throw new Error("failed to save file '" + id + "' to KanaDB");
-    }
+    await kana_db.saveFile(id, buffer);
     collected.push(id);
     return id;
   };
@@ -621,10 +618,7 @@ onmessage = function (msg) {
           let buffer = file.buffer();
           var md5 = await hashwasm.md5(buffer);
           var id = type + "_" + file.name() + "_" + buffer.length + "_" + md5;
-          var ok = await kana_db.saveFile(id, buffer);
-          if (!ok) {
-            throw new Error("failed to save file '" + id + "' to KanaDB");
-          }
+          await kana_db.saveFile(id, buffer);
           buffers.push(id);
           return id;
         };


### PR DESCRIPTION
- All `onerror` statements will now automatically `reject` with an appropriate error message.
- Removed helpers and just repeated the code in the relevant function bodies. This is desirable as IndexedDB operations are closely tied to the event loop and it helps to see that everything is happening in the expected sequence.
