### PR TITLE
Add docker scripts for building static site

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:latest
+ARG UID=1001
+ARG GID=1001
+
+RUN apt-get update && \
+    apt-get install -y curl
+
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
+RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null
+RUN echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update && \
+	apt-get install -y yarn
+
+# Expose the app port
+EXPOSE 3000
+
+# Set up the user and directories
+RUN groupadd -g ${GID} kana
+RUN useradd -rm -d /home/kana -s /bin/bash -g ${GID} -G sudo -u ${UID} kana
+
+USER kana
+
+WORKDIR /home/kana
+
+# Start the app
+#CMD yarn && yarn start
+
+# Build a static version of the app for deployment
+CMD yarn && PUBLIC_URL="/kana" yarn build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  web:
+    build:
+      context: .
+      args:
+        UID: 1001
+        GID: 1001
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/home/kana
+


### PR DESCRIPTION
Adds a couple of docker scripts to allow the static site to be easily built, or to allow the site to be run locally for development.

This PR relates to a [JOSS review](https://github.com/openjournals/joss-reviews/issues/5603); we'll create an issue related to this for more context.

We appreciate you may not want to go down the route of encouraging docker for building the site, but we felt some additional details in the README for how to perform the static site build would be really helpful for newcomers. We're hoping these scripts may be helpful as they encapsulate the steps we had to take to get to that point.