### PR TITLE
Fix references to unique factor levels in UI.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kana",
   "description": "Single-cell data analysis in the browser",
-  "version": "3.0.17",
+  "version": "3.0.18",
   "author": {
     "name": "Jayaram Kancherla",
     "email": "jayaram.kancherla@gmail.com",

--- a/src/components/NewAnalysis/index.js
+++ b/src/components/NewAnalysis/index.js
@@ -845,7 +845,7 @@ export function NewAnalysis({ setShowPanel, setStateIndeterminate, ...props }) {
                 if (col.type === "categorical") {
                   return (
                     <div className="subset-section">
-                      {col.__unique__.map((x) => (
+                      {col.values.map((x) => (
                         <Checkbox
                           key={"subset-" + x}
                           checked={subset.values.includes(x)}
@@ -950,7 +950,7 @@ export function NewAnalysis({ setShowPanel, setStateIndeterminate, ...props }) {
                         <>
                           <Divider />
                           <div className="subset-section">
-                            {col.__unique__.map((x) => (
+                            {col.values.map((x) => (
                               <Checkbox
                                 key={"subset-" + x}
                                 checked={subset.values.includes(x)}


### PR DESCRIPTION
Fixes #241, stemming from some old uses of `__unique__`.

This all fundamentally stems from the fact that the logic in

https://github.com/kanaverse/kana/blame/271f1f1ff84be447c750ff373c8c7cbaf41698df/src/workers/helpers.js#L356-L381

is pretty difficult to follow when considering the opaque output of `summarizeArray`.

I'd suggest moving the source of `summarizeArray` out of **bakana** and into this file, to avoid future surprises from misunderstandings of the `summarizeArray` output. 