### PR TITLE
Correctly pass options to the bakana result readers.

### DIFF
--- a/src/components/ExploreMode/index.js
+++ b/src/components/ExploreMode/index.js
@@ -1411,6 +1411,7 @@ export function ExplorerMode() {
           {showPanel === "explore-import" && (
             <LoadExplore
               setShowPanel={setShowPanel}
+              selectedFsetModality={selectedFsetModality}
               setSelectedFsetModality={setSelectedFsetModality}
             />
           )}

--- a/src/components/LoadExplore/SECard.js
+++ b/src/components/LoadExplore/SECard.js
@@ -140,6 +140,7 @@ export function SECard({
                             let tmpOptions = { ...options };
                             if (e.target.value === "none") {
                               delete tmpOptions["primaryAssay"][x];
+                              delete tmpOptions["isPrimaryNormalized"][x];
                             } else {
                               tmpOptions["primaryAssay"][x] = e.target.value;
                             }

--- a/src/components/LoadExplore/ZippedADBCard.js
+++ b/src/components/LoadExplore/ZippedADBCard.js
@@ -160,6 +160,7 @@ export function ZippedADBCard({
                             let tmpOptions = { ...options };
                             if (e.target.value === "none") {
                               delete tmpOptions["primaryAssay"][x];
+                              delete tmpOptions["isPrimaryNormalized"][x];
                             } else {
                               tmpOptions["primaryAssay"][x] = e.target.value;
                             }

--- a/src/components/LoadExplore/index.js
+++ b/src/components/LoadExplore/index.js
@@ -71,7 +71,7 @@ export function LoadExplore({ setShowPanel, ...props }) {
   const handleExplore = () => {
     let mapFiles = {};
     mapFiles[tmpLoadInputs.name] = tmpLoadInputs;
-    mapFiles[tmpLoadInputs.name]["options"] = inputOptions;
+    mapFiles[tmpLoadInputs.name]["options"] = inputOptions[0];
 
     let fInputFiles = { files: mapFiles };
     setExploreFiles(fInputFiles);

--- a/src/components/LoadExplore/index.js
+++ b/src/components/LoadExplore/index.js
@@ -345,6 +345,7 @@ export function LoadExplore({ setShowPanel, ...props }) {
                     setInputOpts={setInputOptions}
                     inputs={exploreInputs}
                     setInputs={setExploreInputs}
+                    selectedFsetModality={props?.selectedFsetModality}
                     setSelectedFsetModality={props?.setSelectedFsetModality}
                   />
                 );
@@ -365,6 +366,7 @@ export function LoadExplore({ setShowPanel, ...props }) {
                     setInputOpts={setInputOptions}
                     inputs={exploreInputs}
                     setInputs={setExploreInputs}
+                    selectedFsetModality={props?.selectedFsetModality}
                     setSelectedFsetModality={props?.setSelectedFsetModality}
                   />
                 );
@@ -385,6 +387,7 @@ export function LoadExplore({ setShowPanel, ...props }) {
                     setInputOpts={setInputOptions}
                     inputs={exploreInputs}
                     setInputs={setExploreInputs}
+                    selectedFsetModality={props?.selectedFsetModality}
                     setSelectedFsetModality={props?.setSelectedFsetModality}
                   />
                 );


### PR DESCRIPTION
This can either be done as I've shown, or it can be done by modifying the `useEffect` on **each** card to avoid an unnecessary nesting of options - for example, in the SE result reader:

https://github.com/kanaverse/kana/blob/e6764a7a607f3e2c4b226cd1d59631f77ef22261/src/components/LoadExplore/SECard.js#L65-L67

There is only ever one dataset, so there's no point doing this nesting.

This provides a user-level fix to #246, rather than requiring removal of the offending data from the file.