### PR TITLE
Protect against missing feature names in explore mode.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kana",
   "description": "Single-cell data analysis in the browser",
-  "version": "3.0.18",
+  "version": "3.0.19",
   "author": {
     "name": "Jayaram Kancherla",
     "email": "jayaram.kancherla@gmail.com",

--- a/src/components/ExploreMode/index.js
+++ b/src/components/ExploreMode/index.js
@@ -709,7 +709,6 @@ export function ExplorerMode() {
       info.push(`${resp.num_cells} cells`);
 
       setInitDims(info.join(", "));
-      setInputData(resp);
 
       let pmods = Object.keys(resp.genes);
       setModality(pmods);
@@ -718,6 +717,20 @@ export function ExplorerMode() {
       if (selectedModality === null) {
         setSelectedModality(tmodality);
       }
+
+      // Auto-generating rowdata if the per-modality feature annotation is empty.
+      for (const p of pmods) {
+          let mod_gene_info = resp.genes[p]
+          if (Object.keys(mod_gene_info).length == 0) {
+              let dummy = new Int32Array(resp.num_genes[p])
+              for (var i = 0; i < dummy.length; ++i) {
+                  dummy[i] = i;
+              }
+              mod_gene_info["index"] = dummy
+          }
+      }
+ 
+      setInputData(resp);
 
       if (resp?.annotations) {
         setAnnotationCols(resp.annotations);


### PR DESCRIPTION
Closes #247. This is occasionally useful to ensure that the app does something sensible when feature information is missing for, e.g., alternative experiments that no one cares about.

Note that it doesn't solve the case of missing names in analysis mode, which is trickier as **bakana** handles the intersection of features (via **scran.js**'s `cbindWithNames`). 

I suspect that the more general solution is to just ignore all modalities without feature information in **bakana**'s readers, as the lack of feature information will kill a few downstream steps. But this will do for now.