### PR TITLE
Show all cell annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kana",
   "description": "Single-cell data analysis in the browser",
-  "version": "3.0.20",
+  "version": "3.0.21",
   "author": {
     "name": "Jayaram Kancherla",
     "email": "jayaram.kancherla@gmail.com",

--- a/src/components/Plots/DimPlot.js
+++ b/src/components/Plots/DimPlot.js
@@ -831,10 +831,10 @@ const DimPlot = (props) => {
     return Object.keys(annotationCols).filter((x) =>
       !annotationCols[x].name.startsWith(code) &&
       annotationCols[x].name !== "__batch__"
-        ? annotationCols[x]["type"] === "continuous"
-          ? true
-          : !annotationCols[x]["truncated"]
-        : false
+        // ? annotationCols[x]["type"] === "continuous"
+        //   ? true
+        //   : !annotationCols[x]["truncated"]
+        // : false
     );
   }, [annotationCols]);
 


### PR DESCRIPTION
Shows all cell annotations to color dimensionality plots by. Does not truncate columns by number of unique categories anymore. 

Fixes: #253 