### PR TITLE
Fix for incorrect type return in annotation value selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kana",
   "description": "Single-cell data analysis in the browser",
-  "version": "3.0.21",
+  "version": "3.0.22",
   "author": {
     "name": "Jayaram Kancherla",
     "email": "jayaram.kancherla@gmail.com",

--- a/src/components/CellAnnotation/index.js
+++ b/src/components/CellAnnotation/index.js
@@ -507,6 +507,13 @@ const CellAnnotation = (props) => {
                 props?.setSelectedCellAnnCluster(tmpselection);
                 setClusIdx(1);
               } else {
+                // do the best
+                if (annotationObj[props?.selectedCellAnnAnnotation].values.constructor.name.includes("Float")) {
+                  tmpselection = parseFloat(tmpselection)
+                } else if (annotationObj[props?.selectedCellAnnAnnotation].values.constructor.name.includes("Int")) {
+                  tmpselection = parseInt(tmpselection)
+                }
+
                 props?.setSelectedCellAnnCluster(tmpselection);
                 setClusIdx(clusSel.map((x) => String(x)).indexOf(tmpselection));
               }

--- a/src/components/ExploreMode/index.js
+++ b/src/components/ExploreMode/index.js
@@ -639,7 +639,7 @@ export function ExplorerMode() {
   scranWorker.onmessage = (msg) => {
     const payload = msg.data;
 
-    console.log("ON EXPLORE MAIN::RCV::", payload);
+    // console.log("ON EXPLORE MAIN::RCV::", payload);
 
     // process any error messages
     if (payload) {

--- a/src/components/FeatureSets/index.js
+++ b/src/components/FeatureSets/index.js
@@ -887,6 +887,13 @@ const FeatureSetEnrichment = (props) => {
                   parseInt(tmpselection.replace("Cluster ", "")) - 1;
               } else if (default_selection === props?.selectedFsetAnnotation) {
                 tmpselection = tmpselection.replace("Custom Selection ", "");
+              } else {
+                // do the best
+                if (annotationObj[props?.selectedFsetAnnotation].values.constructor.name.includes("Float")) {
+                  tmpselection = parseFloat(tmpselection)
+                } else if (annotationObj[props?.selectedFsetAnnotation].values.constructor.name.includes("Int")) {
+                  tmpselection = parseInt(tmpselection)
+                }
               }
 
               props?.setSelectedFsetCluster(tmpselection);
@@ -957,6 +964,13 @@ const FeatureSetEnrichment = (props) => {
                       "Custom Selection ",
                       ""
                     );
+                  } else {
+                    // do the best
+                    if (annotationObj[props?.selectedFsetAnnotation].values.constructor.name.includes("Float")) {
+                      tmpselection = parseFloat(tmpselection)
+                    } else if (annotationObj[props?.selectedFsetAnnotation].values.constructor.name.includes("Int")) {
+                      tmpselection = parseInt(tmpselection)
+                    }
                   }
                   props?.setSelectedFsetVSCluster(tmpselection);
 

--- a/src/components/Markers/index.js
+++ b/src/components/Markers/index.js
@@ -809,6 +809,13 @@ const MarkerPlot = (props) => {
                 default_selection === props?.selectedMarkerAnnotation
               ) {
                 tmpselection = tmpselection.replace("Custom Selection ", "");
+              } else {
+                // do the best
+                if (annotationObj[props?.selectedMarkerAnnotation].values.constructor.name.includes("Float")) {
+                  tmpselection = parseFloat(tmpselection)
+                } else if (annotationObj[props?.selectedMarkerAnnotation].values.constructor.name.includes("Int")) {
+                  tmpselection = parseInt(tmpselection)
+                }
               }
 
               props?.setSelectedCluster(tmpselection);
@@ -878,6 +885,13 @@ const MarkerPlot = (props) => {
                       "Custom Selection ",
                       ""
                     );
+                  } else {
+                    // do the best
+                    if (annotationObj[props?.selectedMarkerAnnotation].values.constructor.name.includes("Float")) {
+                      tmpselection = parseFloat(tmpselection)
+                    } else if (annotationObj[props?.selectedMarkerAnnotation].values.constructor.name.includes("Int")) {
+                      tmpselection = parseInt(tmpselection)
+                    }
                   }
                   props?.setSelectedVSCluster(tmpselection);
 

--- a/src/workers/KanaDBHandler.js
+++ b/src/workers/KanaDBHandler.js
@@ -317,7 +317,7 @@ function remove_file(id, file_store, meta_store) {
     };
 
     request.onerror = event => {
-      console.log(event);
+      // console.log(event);
       reject(new Error(`failed to retrieve file metadata ${id} from KanaDB: ${event.target.errorCode}`));
     };
   });


### PR DESCRIPTION
This resolves an issue identified in the "explore" mode, where annotation values are integers (mostly found with cluster selection). However, when a user selects a specific cluster, html returns the value as a string. We implemented a type detection mechanism to infer the original type and convert the string value back to its original type.